### PR TITLE
inline-svg: support Vite 6

### DIFF
--- a/packages/inline-svg/package.json
+++ b/packages/inline-svg/package.json
@@ -88,7 +88,7 @@
 	},
 	"peerDependencies": {
 		"svelte": "^5.1.0",
-		"vite": "^5.4.8"
+		"vite": "^5.4.8 || ^6.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"


### PR DESCRIPTION
This commit allows inline-svg to support vite 6 as a peer dependency